### PR TITLE
Fixed MVC reference bug and ReturnUrl label not being hidden correclty

### DIFF
--- a/src/NakedIdentity.Mvc/NakedIdentity.Mvc.csproj
+++ b/src/NakedIdentity.Mvc/NakedIdentity.Mvc.csproj
@@ -103,6 +103,7 @@
     </Reference>
     <Reference Include="System.Web.Mvc">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.0.0\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NakedIdentity.Mvc/ViewModels/LogInModel.cs
+++ b/src/NakedIdentity.Mvc/ViewModels/LogInModel.cs
@@ -13,7 +13,7 @@ namespace NakedIdentity.Mvc.ViewModels
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
-        [HiddenInput]
+        [HiddenInput(DisplayValue=false)]
         public string ReturnUrl { get; set; }
     }
 }


### PR DESCRIPTION
Hi,
I'm going through your Blog article on ASP.NET identity which I'm finding very useful.  While working through it I've run into a few issues which I've fixed in my fork.  
Do you agree with the fixes I've done?  The Return URL one seems quite simple but the MVC reference issue I had seems quite odd.  I don't really understand why I have to copy the MVC dll for this to work.
I'd appreciate your thoughts.

Regards

Ross
